### PR TITLE
build: cleanup automerge workflow

### DIFF
--- a/.github/workflows/pr-automerge-open-release.yml
+++ b/.github/workflows/pr-automerge-open-release.yml
@@ -61,8 +61,10 @@ jobs:
         body: |
           :+1:
 
-          When you're ready to merge, add a comment that says `@edx-community-bot merge`;
-          we'll handle the rest.
+          When you're ready to merge, add a comment that says
+          > @edx-community-bot merge
+
+          and we'll handle the rest!
           CC: @${{ secrets.CC_TEAM_CHAMPIONS }}
     - name: label PR as auto-mergeable
       if: ${{ steps.teams.outputs.isTeamMember == 'true' && contains(github.event.comment.body, '@edx-community-bot merge') }}
@@ -70,22 +72,11 @@ jobs:
       with:
         add-labels: 'automerge'
         repo-token: ${{ secrets.CC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-    - name: react to comment
-      if: ${{ steps.teams.outputs.isTeamMember == 'true' && contains(github.event.comment.body, '@edx-community-bot merge') }}
-      run: |
-        curl \
-          -X POST \
-          -H 'Accept: application/vnd.github.v3+json' \
-          -H "authorization: Bearer ${{ secrets.CC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}" \
-          -H "Accept: application/vnd.github.squirrel-girl-preview" \
-          https://api.github.com/repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.id }}/reactions \
-          -d '{"content": "rocket"}' \
-        ;
     - name: automerge
       uses: "pascalgn/automerge-action@v0.13.1"
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         MERGE_COMMIT_MESSAGE: |
-          merge: PR #{pullRequest.number}: {pullRequest.title}
+          merge(#{pullRequest.number}): {pullRequest.title}
 
           {pullRequest.body}


### PR DESCRIPTION
- remove non-functioning reaction (API/permissions wonkiness)
- make it easier to (triple-click) select the bot text for copy/pasting
- cleanup merge message